### PR TITLE
Support stripe_express: true in the the OmniAuth URL helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ Then you can hit `/auth/stripe_connect`
 
 If you hit `/auth/stripe_connect` with any query params, they will be passed along to Stripe. You can access these params from `request.env['omniauth.params']`. Read [Stripe's OAuth Reference](https://stripe.com/docs/connect/reference) for more information.
 
-### Stripe Express
+### Stripe Connect Express
 
-Stripe Express is supported by declaring the `stripe_express` and `suggested_capabilities` params, for example (with Devise):
+Stripe Connect Express accounts are supported by declaring the `stripe_express` and `suggested_capabilities` params (devise example):
 
 ```ruby
 config.omniauth :stripe_connect, "STRIPE_CONNECT_CLIENT_ID", "STRIPE_SECRET", stripe_express: true, suggested_capabilities: ['transfers']
 ```
 
-If you need to to support both Standard and Express accounts in the same project you also have the option of setting these paramters using the omniauth url helper, eg:
+If you need to to support both Standard and Express accounts in the same project you also have the option of setting these paramters using the omniauth url helper:
 
 ```ruby
 <%= link_to 'Authorize Stripe Connect', user_stripe_connect_omniauth_authorize_path(redirect_uri: user_stripe_connect_omniauth_callback_url, stripe_express: true, suggested_capabilities: ['transfers']) %>

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Then you can hit `/auth/stripe_connect`
 
 If you hit `/auth/stripe_connect` with any query params, they will be passed along to Stripe. You can access these params from `request.env['omniauth.params']`. Read [Stripe's OAuth Reference](https://stripe.com/docs/connect/reference) for more information.
 
+### Stripe Express
+
+Stripe Express is supported by declaring the `stripe_express` and `suggested_capabilities` params, for example (with Devise):
+
+```ruby
+config.omniauth :stripe_connect, "STRIPE_CONNECT_CLIENT_ID", "STRIPE_SECRET", stripe_express: true, suggested_capabilities: ['transfers']
+```
+
+If you need to to support both Standard and Express accounts in the same project you also have the option of setting these paramters using the omniauth url helper, eg:
+
+```ruby
+<%= link_to 'Authorize Stripe Connect', user_stripe_connect_omniauth_authorize_path(redirect_uri: user_stripe_connect_omniauth_callback_url, stripe_express: true, suggested_capabilities: ['transfers']) %>
+```
+
 ## Auth Hash
 
 Here is an example of the Auth Hash you get back from calling `request.env['omniauth.auth']`:

--- a/lib/omniauth/strategies/stripe_connect.rb
+++ b/lib/omniauth/strategies/stripe_connect.rb
@@ -85,7 +85,7 @@ module OmniAuth
 
       def request_phase
         stripe_client = client
-        stripe_client.options[:authorize_url] = "/express/oauth/authorize" if options[:stripe_express]
+        stripe_client.options[:authorize_url] = "/express/oauth/authorize" if options[:stripe_express] || (authorize_params['stripe_express'] == 'true')
 
         redirect stripe_client.auth_code.authorize_url(authorize_params)
       end


### PR DESCRIPTION
This PR allows the user to override the global stripe_express OmniAuth param at the point of redirection to allow projects to mix and match between Stripe Connect Standard (free) and Express (paid) accounts.

Also updated the docs.